### PR TITLE
Feature: More rules.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Current TS File",
+            "name": "Test runner debug",
             "type": "node",
             "request": "launch",
             "program": "${workspaceRoot}/node_modules/ts-node/dist/_bin.js",

--- a/README.md
+++ b/README.md
@@ -1,24 +1,147 @@
 # simplr-tslint
+
 A set of [TSLint](https://palantir.github.io/tslint/) rules used in SimplrJS projects.
 
-# Get started
+## Get started
+
 ```cmd
 npm install simplr-tslint --save-dev
 ```
 
-# How to use?
-Add this line in your `tslint.json` file: 
+## How to use?
+
+Add this line in your `tslint.json` file:
+
 ```json
 {
     "extends": "simplr-tslint"
 }
 ```
+
 Or:
+
 ```json
 {
     "extends": ["simplr-tslint"]
 }
 ```
 
-# License
+## Custom rules
+
+### `class-members-name`
+
+Enforces consistent naming style in interface and class declarations.
+
+#### Format rule
+
+| Name              | Type                                                               | Optional | Default  |
+| ----------------- | ------------------------------------------------------------------ | -------- | -------- |
+| kind              | "getter", "setter", "method", "property"                           | Required |          |
+| modifier          | "public", "private", "protected"                                   | Optional | "public" |
+| format            | "none", "camel-case", "pascal-case", "constant-case", "snake-case" | Optional | "none"   |
+| isStatic          | boolean                                                            | Optional | false    |
+| leadingUnderscore | boolean                                                            | Optional | false    |
+
+#### Config examples
+
+Enforces all members naming to `camel-case` format.
+
+```json
+"class-members-name": true
+```
+
+Enforces all members naming to `pascal-case` format.
+
+```json
+"class-members-name": [true, "pascal-case"]
+```
+
+Enforces all members naming to `pascal-case` format. Skips origin checking in heritage. Useful when migrating coding style.
+
+```json
+"class-members-name": [true, "pascal-case", "skip-origin-checking"]
+```
+
+C# coding style example.
+
+```json
+"class-members-name": [
+    true,
+    [
+        { "kind": "method", "modifier": "public", "format": "pascal-case" },
+        { "kind": "method", "modifier": "protected", "format": "pascal-case" },
+        { "kind": "method", "modifier": "private", "format": "camel-case" },
+        { "kind": "property", "modifier": "public", "format": "pascal-case" },
+        { "kind": "property", "modifier": "protected", "format": "pascal-case" },
+        { "kind": "property", "modifier": "private", "format": "camel-case" },
+        { "kind": "getter", "modifier": "public", "format": "pascal-case" },
+        { "kind": "getter", "modifier": "protected", "format": "pascal-case" },
+        { "kind": "getter", "modifier": "private", "format": "camel-case" },
+        { "kind": "setter", "modifier": "public", "format": "pascal-case" },
+        { "kind": "setter", "modifier": "protected", "format": "pascal-case" },
+        { "kind": "setter", "modifier": "private", "format": "camel-case" }
+    ]
+]
+```
+
+### `const-variable-name`
+
+Const variables in source file or in module must have constant-case.
+
+#### Examples
+
+```ts
+export const FOO_FOO = "Hello World!";
+
+export const fooBar = "Hello World!";
+        //   ~~~~~~                    [Const variables in source file or in module declaration must have (constant-case) format.]
+
+export namespace FooNamespace {
+    export const PACKAGE_VERSION: string = "v1.0.0";
+
+    export function test(): void {
+        const variableInFunctionScope: string = "Hello.";
+    }
+}
+
+```
+
+#### Config example
+
+```json
+"const-variable-name": true
+```
+
+### `exported-namespace-member`
+
+All module members must be exported.
+
+#### Config example
+
+```json
+"exported-namespace-member": true
+```
+
+### `type-parameter-name`
+
+Type parameter's name must start with "T" prefix.
+
+#### Example
+
+```ts
+export type Foo<Value> = [string, Value];
+            //  ~~~~~                      [Type parameter's name must start with "T" prefix.]
+
+export type Bar<TValue> = [string, TValue];
+
+```
+
+#### Config example
+
+```json
+"type-parameter-name": true
+```
+
+## License
+
 Released under the [MIT license](LICENSE).

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -247,26 +247,32 @@ class ClassMembersWalker extends Lint.ProgramAwareRuleWalker {
 
     public visitMethodSignature(node: ts.MethodSignature): void {
         this.checkMethod(node, node.name, MemberKind.Method);
+        super.visitMethodSignature(node);
     }
 
     public visitMethodDeclaration(node: ts.MethodDeclaration): void {
         this.checkMethod(node, node.name, MemberKind.Method);
+        super.visitMethodDeclaration(node);
     }
 
     public visitPropertySignature(node: ts.PropertySignature): void {
         this.checkMethod(node, node.name, MemberKind.Property);
+        super.visitPropertySignature(node);
     }
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration): void {
         this.checkMethod(node, node.name, MemberKind.Property);
+        super.visitPropertyDeclaration(node);
     }
 
     public visitGetAccessor(node: ts.GetAccessorDeclaration): void {
         this.checkMethod(node, node.name, MemberKind.Getter);
+        super.visitGetAccessor(node);
     }
 
     public visitSetAccessor(node: ts.SetAccessorDeclaration): void {
         this.checkMethod(node, node.name, MemberKind.Setter);
+        super.visitSetAccessor(node);
     }
 
     private checkMethod(node: ts.Declaration, name: ts.Node, kind: MemberKind): void {

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -28,7 +28,7 @@ enum MemberKind {
 interface FormatRule {
     kind: MemberKind;
     /**
-     * @default "any"
+     * @default "public"
      */
     modifier?: AccessModifier;
     /**

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -177,7 +177,7 @@ namespace TsHelpers {
 }
 
 export class Rule extends Lint.Rules.TypedRule {
-    public static failureStringFactory(name: string, neededCase: string): string {
+    public static failureMessageFactory(name: string, neededCase: string): string {
         return `Declaration "${name}" format is not correct (${neededCase}).`;
     }
 
@@ -240,7 +240,7 @@ class ClassMembersWalker extends Lint.ProgramAwareRuleWalker {
             const fix = new Lint.Replacement(nameNode.getStart(), nameNode.getWidth(), casedName);
 
             // create a failure at the current position
-            this.addFailure(this.createFailure(nameNode.getStart(), nameNode.getWidth(), Rule.failureStringFactory(name, format), fix));
+            this.addFailure(this.createFailure(nameNode.getStart(), nameNode.getWidth(), Rule.failureMessageFactory(name, format), fix));
         }
     }
     //#endregion

--- a/src/constVariableNameRule.ts
+++ b/src/constVariableNameRule.ts
@@ -6,11 +6,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static readonly failureString: string = "TODO: Add failure string _____";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoImportsWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new ConstVariableWalker(sourceFile, this.getOptions()));
     }
 }
 
-class NoImportsWalker extends Lint.RuleWalker {
+class ConstVariableWalker extends Lint.RuleWalker {
     private isNodeInModuleDeclaration(node: ts.Node): boolean {
         return ts.isModuleBlock(node) && node.parent != null && ts.isModuleDeclaration(node.parent);
     }

--- a/src/constVariableNameRule.ts
+++ b/src/constVariableNameRule.ts
@@ -1,0 +1,39 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+import * as changeCase from "change-case";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static readonly failureString: string = "TODO: Add failure string _____";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoImportsWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoImportsWalker extends Lint.RuleWalker {
+    private isNodeInModuleDeclaration(node: ts.Node): boolean {
+        return ts.isModuleBlock(node) && node.parent != null && ts.isModuleDeclaration(node.parent);
+    }
+
+    public visitVariableStatement(node: ts.VariableStatement): void {
+        super.visitVariableStatement(node);
+        if (node.parent == null || (!ts.isSourceFile(node.parent) && !this.isNodeInModuleDeclaration(node.parent))) {
+            return;
+        }
+
+        const variableDeclarationList = node.declarationList.declarations;
+
+        for (const variableDeclaration of variableDeclarationList) {
+            const name = variableDeclaration.name.getText();
+            const casedName = changeCase.constantCase(name);
+
+            if (name !== casedName) {
+                const nodeNameStart = variableDeclaration.name.getStart();
+                const nodeNameEnd = variableDeclaration.name.getWidth();
+
+                const fix = new Lint.Replacement(nodeNameStart, nodeNameEnd, casedName);
+                this.addFailure(this.createFailure(nodeNameStart, nodeNameEnd, Rule.failureString, fix));
+            }
+        }
+    }
+}

--- a/src/constVariableNameRule.ts
+++ b/src/constVariableNameRule.ts
@@ -3,7 +3,7 @@ import * as Lint from "tslint";
 import * as changeCase from "change-case";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static readonly failureString: string = "TODO: Add failure string _____";
+    public static readonly failureString: string = "Const variables in source file or in module declaration must have constant-case.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new ConstVariableWalker(sourceFile, this.getOptions()));

--- a/src/constVariableNameRule.ts
+++ b/src/constVariableNameRule.ts
@@ -4,7 +4,7 @@ import * as changeCase from "change-case";
 
 export class Rule extends Lint.Rules.AbstractRule {
     // tslint:disable-next-line:max-line-length
-    public static readonly failureString: string = "Const variables in source file or in module declaration must have (constant-case) format";
+    public static readonly failureMessage: string = "Const variables in source file or in module declaration must have (constant-case) format.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new ConstVariableWalker(sourceFile, this.getOptions()));
@@ -33,7 +33,7 @@ class ConstVariableWalker extends Lint.RuleWalker {
                 const nodeNameEnd = variableDeclaration.name.getWidth();
 
                 const fix = new Lint.Replacement(nodeNameStart, nodeNameEnd, casedName);
-                this.addFailure(this.createFailure(nodeNameStart, nodeNameEnd, Rule.failureString, fix));
+                this.addFailure(this.createFailure(nodeNameStart, nodeNameEnd, Rule.failureMessage, fix));
             }
         }
     }

--- a/src/constVariableNameRule.ts
+++ b/src/constVariableNameRule.ts
@@ -3,7 +3,8 @@ import * as Lint from "tslint";
 import * as changeCase from "change-case";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static readonly failureString: string = "Const variables in source file or in module declaration must have constant-case.";
+    // tslint:disable-next-line:max-line-length
+    public static readonly failureString: string = "Const variables in source file or in module declaration must have (constant-case) format";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new ConstVariableWalker(sourceFile, this.getOptions()));

--- a/src/exportedNamespaceMembersRule.ts
+++ b/src/exportedNamespaceMembersRule.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 import * as Lint from "tslint";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static readonly failureString: string = "All module members must be exported.";
+    public static readonly failureMessage: string = "All module members must be exported.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new ExportedNamespaceMembersWalker(sourceFile, this.getOptions()));
@@ -19,7 +19,7 @@ class ExportedNamespaceMembersWalker extends Lint.RuleWalker {
         for (const statement of node.body.statements) {
             if (statement.modifiers == null || statement.modifiers.findIndex(x => x.kind === ts.SyntaxKind.ExportKeyword) === -1) {
                 const fix = new Lint.Replacement(statement.getStart(), 0, "export ");
-                this.addFailureAtNode(statement, Rule.failureString, fix);
+                this.addFailureAtNode(statement, Rule.failureMessage, fix);
             }
         }
     }

--- a/src/exportedNamespaceMembersRule.ts
+++ b/src/exportedNamespaceMembersRule.ts
@@ -1,0 +1,26 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static readonly failureString: string = "All module members must be exported.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new ExportedNamespaceMembersWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class ExportedNamespaceMembersWalker extends Lint.RuleWalker {
+    public visitModuleDeclaration(node: ts.ModuleDeclaration): void {
+        super.visitModuleDeclaration(node);
+        if (node.body == null || !ts.isModuleBlock(node.body)) {
+            return;
+        }
+
+        for (const statement of node.body.statements) {
+            if (statement.modifiers == null || statement.modifiers.findIndex(x => x.kind === ts.SyntaxKind.ExportKeyword) === -1) {
+                const fix = new Lint.Replacement(statement.getStart(), 0, "export ");
+                this.addFailureAtNode(statement, Rule.failureString, fix);
+            }
+        }
+    }
+}

--- a/src/typeParameterNameRule.ts
+++ b/src/typeParameterNameRule.ts
@@ -13,7 +13,7 @@ function hasPrefix(name: string): boolean {
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static readonly failureString: string = "TODO: Add failure string _____";
+    public static readonly failureString: string = `Type parameter's name must start with "${PREFIX}" prefix.`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/src/typeParameterNameRule.ts
+++ b/src/typeParameterNameRule.ts
@@ -13,7 +13,7 @@ function hasPrefix(name: string): boolean {
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static readonly failureString: string = `Type parameter's name must start with "${PREFIX}" prefix.`;
+    public static readonly failureMessage: string = `Type parameter's name must start with "${PREFIX}" prefix.`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -29,7 +29,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 const casedName = PREFIX + changeCase.pascalCase(name);
                 const fix = new Lint.Replacement(node.getStart(), node.getWidth(), casedName);
 
-                ctx.addFailureAtNode(node, Rule.failureString, fix);
+                ctx.addFailureAtNode(node, Rule.failureMessage, fix);
             }
         }
 

--- a/src/typeParameterNameRule.ts
+++ b/src/typeParameterNameRule.ts
@@ -1,0 +1,40 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+import * as changeCase from "change-case";
+
+const PREFIX = "T";
+
+function isUpperCase(str: string): boolean {
+    return str === str.toUpperCase();
+}
+
+function hasPrefix(name: string): boolean {
+    return name.length >= 2 && name[0] === PREFIX && isUpperCase(name[1]);
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static readonly failureString: string = "TODO: Add failure string _____";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    const cb = (node: ts.Node): void => {
+        if (ts.isTypeParameterDeclaration(node)) {
+            const name = node.name.getText();
+
+            if (!hasPrefix(name)) {
+                const casedName = PREFIX + changeCase.pascalCase(name);
+                const fix = new Lint.Replacement(node.getStart(), node.getWidth(), casedName);
+
+                ctx.addFailureAtNode(node, Rule.failureString, fix);
+            }
+        }
+
+        return ts.forEachChild(node, cb);
+    };
+
+    return ts.forEachChild(ctx.sourceFile, cb);
+}

--- a/test/rules/const-variable-name/default/test.ts.fix
+++ b/test/rules/const-variable-name/default/test.ts.fix
@@ -1,0 +1,9 @@
+export const FOO_BAR = "Hello World!";
+
+export namespace FooNamespace {
+    export const PACKAGE_VERSION: string = "v1.0.0";
+
+    export function test(): void {
+        const variableInFunctionScope: string = "Hello.";
+    }
+}

--- a/test/rules/const-variable-name/default/test.ts.lint
+++ b/test/rules/const-variable-name/default/test.ts.lint
@@ -1,9 +1,9 @@
 export const fooBar = "Hello World!";
-             ~~~~~~                    [Const variables in source file or in module declaration must have constant-case.]
+             ~~~~~~                    [Const variables in source file or in module declaration must have (constant-case) format.]
 
 export namespace FooNamespace {
     export const PackageVersion: string = "v1.0.0";
-                 ~~~~~~~~~~~~~~                      [Const variables in source file or in module declaration must have constant-case.]
+                 ~~~~~~~~~~~~~~                      [Const variables in source file or in module declaration must have (constant-case) format.]
 
     export function test(): void {
         const variableInFunctionScope: string = "Hello.";

--- a/test/rules/const-variable-name/default/test.ts.lint
+++ b/test/rules/const-variable-name/default/test.ts.lint
@@ -1,9 +1,9 @@
 export const fooBar = "Hello World!";
-             ~~~~~~                    [TODO: Add failure string _____]
+             ~~~~~~                    [Const variables in source file or in module declaration must have constant-case.]
 
 export namespace FooNamespace {
     export const PackageVersion: string = "v1.0.0";
-                 ~~~~~~~~~~~~~~               [TODO: Add failure string _____]
+                 ~~~~~~~~~~~~~~                      [Const variables in source file or in module declaration must have constant-case.]
 
     export function test(): void {
         const variableInFunctionScope: string = "Hello.";

--- a/test/rules/const-variable-name/default/test.ts.lint
+++ b/test/rules/const-variable-name/default/test.ts.lint
@@ -1,0 +1,11 @@
+export const fooBar = "Hello World!";
+             ~~~~~~                    [TODO: Add failure string _____]
+
+export namespace FooNamespace {
+    export const PackageVersion: string = "v1.0.0";
+                 ~~~~~~~~~~~~~~               [TODO: Add failure string _____]
+
+    export function test(): void {
+        const variableInFunctionScope: string = "Hello.";
+    }
+}

--- a/test/rules/const-variable-name/default/tslint.json
+++ b/test/rules/const-variable-name/default/tslint.json
@@ -1,0 +1,6 @@
+{
+    "rulesDirectory": "../../../../rules",
+    "rules": {
+        "const-variable-name": true
+    }
+}

--- a/test/rules/exported-namespace-members/default/test.ts.fix
+++ b/test/rules/exported-namespace-members/default/test.ts.fix
@@ -1,0 +1,5 @@
+export namespace Foo {
+    export const version: string = "v1.0.0";
+
+    export function internalFunction(): void {}
+}

--- a/test/rules/exported-namespace-members/default/test.ts.lint
+++ b/test/rules/exported-namespace-members/default/test.ts.lint
@@ -1,0 +1,6 @@
+export namespace Foo {
+    export const version: string = "v1.0.0";
+
+    function internalFunction(): void {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [All module members must be exported.]
+}

--- a/test/rules/exported-namespace-members/default/tslint.json
+++ b/test/rules/exported-namespace-members/default/tslint.json
@@ -1,0 +1,6 @@
+{
+    "rulesDirectory": "../../../../rules",
+    "rules": {
+        "exported-namespace-members": true
+    }
+}

--- a/test/rules/type-parameter-name-rule/default/test.ts.fix
+++ b/test/rules/type-parameter-name-rule/default/test.ts.fix
@@ -1,0 +1,3 @@
+export type Foo<TValue> = [string, Value];
+
+export type Bar<TValue> = [string, TValue];

--- a/test/rules/type-parameter-name-rule/default/test.ts.lint
+++ b/test/rules/type-parameter-name-rule/default/test.ts.lint
@@ -1,4 +1,4 @@
 export type Foo<Value> = [string, Value];
-                ~~~~~              [TODO: Add failure string _____]
+                ~~~~~                      [Type parameter's name must start with "T" prefix.]
 
 export type Bar<TValue> = [string, TValue];

--- a/test/rules/type-parameter-name-rule/default/test.ts.lint
+++ b/test/rules/type-parameter-name-rule/default/test.ts.lint
@@ -1,0 +1,4 @@
+export type Foo<Value> = [string, Value];
+                ~~~~~              [TODO: Add failure string _____]
+
+export type Bar<TValue> = [string, TValue];

--- a/test/rules/type-parameter-name-rule/default/tslint.json
+++ b/test/rules/type-parameter-name-rule/default/tslint.json
@@ -1,0 +1,6 @@
+{
+    "rulesDirectory": "../../../../rules",
+    "rules": {
+        "type-parameter-name": true
+    }
+}

--- a/test/test-runner.ts
+++ b/test/test-runner.ts
@@ -10,8 +10,8 @@ import { consoleTestResultHandler, runTest } from "tslint/lib/test";
 process.stdout.write("\nTesting Lint Rules:\n");
 
 const rulesDirectory = path.resolve(process.cwd(), "../rules");
-const testDirectories = glob.sync("./rules/**/tslint.json").map(path.dirname);
-// const testDirectories = ["./rules/class-members-name/everything-is-pascal-case"];
+// const testDirectories = glob.sync("./rules/**/tslint.json").map(path.dirname);
+const testDirectories = ["./rules/const-variable-name/default"];
 
 for (const testDirectory of testDirectories) {
     const results = runTest(testDirectory, rulesDirectory);


### PR DESCRIPTION
* `const-variable-name` - Const variables in source file or in module declaration must have (constant-case) format
* `exported-namespace-members` - All module members must be exported
* `type-parameter-name-rule` - Type parameter's name must start with "T" prefix