### PR TITLE
Feature: class-members-name rule upgrade.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Enforces consistent naming style in interface and class declarations.
 
 | Name     | Type                                                               | Optional | Default  |
 | -------- | ------------------------------------------------------------------ | -------- | -------- |
-| kind     | "getter", "setter", "method", "property"                           | Required |          |
+| kind     | "method", "property"                                               | Required |          |
 | modifier | "public", "private", "protected"                                   | Optional | "public" |
 | format   | "none", "camel-case", "pascal-case", "constant-case", "snake-case" | Optional | "none"   |
 | isStatic | boolean                                                            | Optional | false    |

--- a/README.md
+++ b/README.md
@@ -30,17 +30,19 @@ Or:
 
 ### `class-members-name`
 
+**Has Fixer**
+
 Enforces consistent naming style in interface and class declarations.
 
 #### Format rule
 
-| Name              | Type                                                               | Optional | Default  |
-| ----------------- | ------------------------------------------------------------------ | -------- | -------- |
-| kind              | "getter", "setter", "method", "property"                           | Required |          |
-| modifier          | "public", "private", "protected"                                   | Optional | "public" |
-| format            | "none", "camel-case", "pascal-case", "constant-case", "snake-case" | Optional | "none"   |
-| isStatic          | boolean                                                            | Optional | false    |
-| leadingUnderscore | boolean                                                            | Optional | false    |
+| Name     | Type                                                               | Optional | Default  |
+| -------- | ------------------------------------------------------------------ | -------- | -------- |
+| kind     | "getter", "setter", "method", "property"                           | Required |          |
+| modifier | "public", "private", "protected"                                   | Optional | "public" |
+| format   | "none", "camel-case", "pascal-case", "constant-case", "snake-case" | Optional | "none"   |
+| isStatic | boolean                                                            | Optional | false    |
+| prefix   | string                                                             | Optional |          |
 
 #### Config examples
 
@@ -84,7 +86,32 @@ C# coding style example.
 ]
 ```
 
+Private with leading underscore and Protected with leading two underscores.
+
+```json
+"class-members-name": [
+    true,
+    [
+        { "kind": "method", "modifier": "public", "format": "camel-case" },
+        { "kind": "method", "modifier": "protected", "format": "camel-case", "prefix": "__" },
+        { "kind": "method", "modifier": "private", "format": "camel-case", "prefix": "_" },
+        { "kind": "property", "modifier": "public", "format": "camel-case" },
+        { "kind": "property", "modifier": "protected", "format": "camel-case", "prefix": "__" },
+        { "kind": "property", "modifier": "private", "format": "camel-case", "prefix": "_" },
+        { "kind": "getter", "modifier": "public", "format": "camel-case" },
+        { "kind": "getter", "modifier": "protected", "format": "camel-case", "prefix": "__" },
+        { "kind": "getter", "modifier": "private", "format": "camel-case", "prefix": "_" },
+        { "kind": "setter", "modifier": "public", "format": "camel-case" },
+        { "kind": "setter", "modifier": "protected", "format": "camel-case", "prefix": "__" },
+        { "kind": "setter", "modifier": "private", "format": "camel-case", "prefix": "_" }
+    ]
+]
+```
+
 ### `const-variable-name`
+
+**Has Fixer**
+
 
 Const variables in source file or in module must have constant-case.
 
@@ -94,7 +121,7 @@ Const variables in source file or in module must have constant-case.
 export const FOO_FOO = "Hello World!";
 
 export const fooBar = "Hello World!";
-        //   ~~~~~~                    [Const variables in source file or in module declaration must have (constant-case) format.]
+//   ~~~~~~                    [Const variables in source file or in module declaration must have (constant-case) format.]
 
 export namespace FooNamespace {
     export const PACKAGE_VERSION: string = "v1.0.0";
@@ -103,7 +130,6 @@ export namespace FooNamespace {
         const variableInFunctionScope: string = "Hello.";
     }
 }
-
 ```
 
 #### Config example
@@ -113,6 +139,8 @@ export namespace FooNamespace {
 ```
 
 ### `exported-namespace-member`
+
+**Has Fixer**
 
 All module members must be exported.
 
@@ -124,16 +152,17 @@ All module members must be exported.
 
 ### `type-parameter-name`
 
+**Has Fixer**
+
 Type parameter's name must start with "T" prefix.
 
 #### Example
 
 ```ts
 export type Foo<Value> = [string, Value];
-            //  ~~~~~                      [Type parameter's name must start with "T" prefix.]
+//  ~~~~~                      [Type parameter's name must start with "T" prefix.]
 
 export type Bar<TValue> = [string, TValue];
-
 ```
 
 #### Config example

--- a/README.md
+++ b/README.md
@@ -75,13 +75,7 @@ C# coding style example.
         { "kind": "method", "modifier": "private", "format": "camel-case" },
         { "kind": "property", "modifier": "public", "format": "pascal-case" },
         { "kind": "property", "modifier": "protected", "format": "pascal-case" },
-        { "kind": "property", "modifier": "private", "format": "camel-case" },
-        { "kind": "getter", "modifier": "public", "format": "pascal-case" },
-        { "kind": "getter", "modifier": "protected", "format": "pascal-case" },
-        { "kind": "getter", "modifier": "private", "format": "camel-case" },
-        { "kind": "setter", "modifier": "public", "format": "pascal-case" },
-        { "kind": "setter", "modifier": "protected", "format": "pascal-case" },
-        { "kind": "setter", "modifier": "private", "format": "camel-case" }
+        { "kind": "property", "modifier": "private", "format": "camel-case" }
     ]
 ]
 ```
@@ -97,13 +91,7 @@ Private with leading underscore and Protected with leading two underscores.
         { "kind": "method", "modifier": "private", "format": "camel-case", "prefix": "_" },
         { "kind": "property", "modifier": "public", "format": "camel-case" },
         { "kind": "property", "modifier": "protected", "format": "camel-case", "prefix": "__" },
-        { "kind": "property", "modifier": "private", "format": "camel-case", "prefix": "_" },
-        { "kind": "getter", "modifier": "public", "format": "camel-case" },
-        { "kind": "getter", "modifier": "protected", "format": "camel-case", "prefix": "__" },
-        { "kind": "getter", "modifier": "private", "format": "camel-case", "prefix": "_" },
-        { "kind": "setter", "modifier": "public", "format": "camel-case" },
-        { "kind": "setter", "modifier": "protected", "format": "camel-case", "prefix": "__" },
-        { "kind": "setter", "modifier": "private", "format": "camel-case", "prefix": "_" }
+        { "kind": "property", "modifier": "private", "format": "camel-case", "prefix": "_" }
     ]
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or:
 
 ### `class-members-name`
 
-**Has Fixer**
+**🔨Has Fixer**
 
 Enforces consistent naming style in interface and class declarations.
 
@@ -98,8 +98,7 @@ Private with leading underscore and Protected with leading two underscores.
 
 ### `const-variable-name`
 
-**Has Fixer**
-
+**🔨Has Fixer**
 
 Const variables in source file or in module must have constant-case.
 
@@ -128,7 +127,7 @@ export namespace FooNamespace {
 
 ### `exported-namespace-member`
 
-**Has Fixer**
+**🔨Has Fixer**
 
 All module members must be exported.
 
@@ -140,7 +139,7 @@ All module members must be exported.
 
 ### `type-parameter-name`
 
-**Has Fixer**
+**🔨Has Fixer**
 
 Type parameter's name must start with "T" prefix.
 

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -19,8 +19,6 @@ enum AccessModifier {
 }
 
 enum MemberKind {
-    Getter = "getter",
-    Setter = "setter",
     Method = "method",
     Property = "property"
 }
@@ -261,12 +259,12 @@ class ClassMembersWalker extends Lint.ProgramAwareRuleWalker {
     }
 
     public visitGetAccessor(node: ts.GetAccessorDeclaration): void {
-        this.checkMethod(node, node.name, MemberKind.Getter);
+        this.checkMethod(node, node.name, MemberKind.Property);
         super.visitGetAccessor(node);
     }
 
     public visitSetAccessor(node: ts.SetAccessorDeclaration): void {
-        this.checkMethod(node, node.name, MemberKind.Setter);
+        this.checkMethod(node, node.name, MemberKind.Property);
         super.visitSetAccessor(node);
     }
 

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -220,7 +220,7 @@ class ClassMembersWalker extends Lint.ProgramAwareRuleWalker {
         return rules[index];
     }
 
-    private checkNameNode(nameNode: ts.Node, format: Format, prefix?: string): void {
+    private checkNameNode(nameNode: ts.Node, format: Format = Format.None, prefix?: string): void {
         const name = nameNode.getText();
         const casedName = FormatHelpers.changeFormat(format, name, prefix);
 
@@ -289,7 +289,7 @@ class ClassMembersWalker extends Lint.ProgramAwareRuleWalker {
                     name.getText()
                 ))
         ) {
-            this.checkNameNode(name, format || Format.None, prefix);
+            this.checkNameNode(name, format, prefix);
         }
     }
 }

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -47,20 +47,6 @@ interface RuleOptions {
 }
 
 namespace FormatHelpers {
-    export function getLeadingUnderscore(text: string): string {
-        let result: string = "";
-
-        for (let i = 0; i < text.length; i++) {
-            if (text[i] !== "_") {
-                break;
-            }
-
-            result += text[i];
-        }
-
-        return result;
-    }
-
     export function changeFormat(format: Format, text: string, prefix?: string): string {
         let textWithoutPrefix: string;
         if (prefix != null && text.startsWith(prefix)) {

--- a/src/classMembersNameRule.ts
+++ b/src/classMembersNameRule.ts
@@ -45,16 +45,12 @@ interface RuleOptions {
 }
 
 namespace FormatHelpers {
-    export function changeFormat(format: Format, text: string, prefix?: string): string {
+    export function changeFormat(format: Format, text: string, prefix: string = ""): string {
         let textWithoutPrefix: string;
-        if (prefix != null && text.startsWith(prefix)) {
+        if (prefix && text.startsWith(prefix)) {
             textWithoutPrefix = text.substring(prefix.length, text.length);
         } else {
             textWithoutPrefix = text;
-        }
-
-        if (prefix == null) {
-            prefix = "";
         }
 
         switch (format) {

--- a/test/rules/class-members-name/c-sharp-style/tslint.json
+++ b/test/rules/class-members-name/c-sharp-style/tslint.json
@@ -9,13 +9,7 @@
                 { "kind": "method", "modifier": "private", "format": "camel-case" },
                 { "kind": "property", "modifier": "public", "format": "pascal-case" },
                 { "kind": "property", "modifier": "protected", "format": "pascal-case" },
-                { "kind": "property", "modifier": "private", "format": "camel-case" },
-                { "kind": "getter", "modifier": "public", "format": "pascal-case" },
-                { "kind": "getter", "modifier": "protected", "format": "pascal-case" },
-                { "kind": "getter", "modifier": "private", "format": "camel-case" },
-                { "kind": "setter", "modifier": "public", "format": "pascal-case" },
-                { "kind": "setter", "modifier": "protected", "format": "pascal-case" },
-                { "kind": "setter", "modifier": "private", "format": "camel-case" }
+                { "kind": "property", "modifier": "private", "format": "camel-case" }
             ]
         ]
     }

--- a/test/rules/class-members-name/underscore-leading/tslint.json
+++ b/test/rules/class-members-name/underscore-leading/tslint.json
@@ -1,6 +1,6 @@
 {
     "rulesDirectory": "../../../../rules",
     "rules": {
-        "class-members-name": [true, [{ "kind": "method", "format": "camel-case", "leadingUnderscore": true }]]
+        "class-members-name": [true, [{ "kind": "method", "format": "camel-case", "prefix": "__" }]]
     }
 }


### PR DESCRIPTION
Changed from `leadingUnderscore: boolean` to `prefix: string`.
Removed `getter` and `setter` kinds to use `property` instead.